### PR TITLE
enh: display the fileName in case of error

### DIFF
--- a/src/BaseFile.php
+++ b/src/BaseFile.php
@@ -112,7 +112,7 @@ abstract class BaseFile extends BaseObject
     {
         $this->_entriesCount++;
         if ($this->_entriesCount > self::MAX_ENTRIES_COUNT) {
-            throw new Exception('Entries count exceeds limit of "' . self::MAX_ENTRIES_COUNT . '".');
+            throw new Exception(sprintf('Entries count exceeds limit of "%d" in "%s".', self::MAX_ENTRIES_COUNT, $this->fileName));
         }
         return $this->_entriesCount;
     }


### PR DESCRIPTION
Hey,

Thank you for this neat library 🙌 

The files splitting is a great feature when you have a lot of contents, I enhanced the error message to tell what file is problematic.