### PR TITLE
Get rid of hardcoded default values

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -72,7 +72,6 @@ class File extends BaseFile
      * @param string|array $url page URL or params.
      * @param array $options options list, valid options are:
      * - 'lastModified' - string|int, last modified date in format Y-m-d or timestamp.
-     *   by default current date will be used.
      * - 'changeFrequency' - string, page change frequency, the following values can be passed:
      *
      *   * always
@@ -83,8 +82,8 @@ class File extends BaseFile
      *   * yearly
      *   * never
      *
-     *   by default 'daily' will be used. You may use constants defined in this class here.
-     * - 'priority' - string|float URL search priority in range 0..1, by default '0.5' will be used
+     *   You may use constants defined in this class here.
+     * - 'priority' - string|float URL search priority in range 0..1
      * @return int the number of bytes written.
      */
     public function writeUrl($url, array $options = [])
@@ -98,22 +97,14 @@ class File extends BaseFile
         $xmlCode = '<url>';
         $xmlCode .= "<loc>{$url}</loc>";
 
-        $options = array_merge(
-            [
-                'lastModified' => date('Y-m-d'),
-                'changeFrequency' => self::CHECK_FREQUENCY_DAILY,
-                'priority' => '0.5',
-            ],
-            $this->defaultOptions,
-            $options
-        );
+        $options = array_merge($this->defaultOptions, $options);
         if (ctype_digit($options['lastModified'])) {
             $options['lastModified'] = date('Y-m-d', $options['lastModified']);
         }
 
-        $xmlCode .= "<lastmod>{$options['lastModified']}</lastmod>";
-        $xmlCode .= "<changefreq>{$options['changeFrequency']}</changefreq>";
-        $xmlCode .= "<priority>{$options['priority']}</priority>";
+        $xmlCode .= $options['lastModified'] ? "<lastmod>{$options['lastModified']}</lastmod>" : '';
+        $xmlCode .= $options['changeFrequency'] ? "<changefreq>{$options['changeFrequency']}</changefreq>" : '';
+        $xmlCode .= $options['priority'] ? "<priority>{$options['priority']}</priority>" : '';
 
         $xmlCode .= '</url>';
         return $this->write($xmlCode);


### PR DESCRIPTION
Hi Paul,
This is a small suggestion for your helpful extension. I made those changes in my project, because of these reasons. I think they apply to everyone. See https://www.sitemaps.org/protocol.html

* In general, the smaller sitemap.xml, the better.
* There is no need to have default priority 0.5, because this is the default value by…default :).
* If I don’t know the lastModified datetime, putting there today’s date is just a lie. It’s better to leave it empty.
* If I don’t know, how frequently is the URL changed, it’s better to leave it empty than lie.
* Mainly – if some attribute is empty, it’s better not to write it to the doc, just skip it. Because they are optional.

With the changes I’ve done, you can still have the default values because of your property defaultOptions. But I think it’s a bad idea to have hardcoded your own default values in the code with no option to get rid of them from the writeUrl() perspective. Even if I override it to null, it’s still part of the xml.